### PR TITLE
correcciones rangos de precio y periodicidad de alquiler

### DIFF
--- a/src/front/js/component/aside.js
+++ b/src/front/js/component/aside.js
@@ -76,12 +76,49 @@ export const Aside = () => {
               ))}
             </select>
           </div>
+          {/* Periodo de Alquiler */}
+          {store.operacion == "alquiler" ? (
+            <div className="mx-3 mb-3">
+              <div className="pb-2">
+                <span className="">Alquiler por:</span>
+              </div>
+              <div className="form-check">
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  name="exampleRadios"
+                  id="exampleRadios1"
+                  checked={store.periodo_alquiler == "por meses" ? true : false}
+                  onChange={actions.bulletMonth}
+                />
+                <label className="form-check-label" for="exampleRadios1">
+                  Meses
+                </label>
+              </div>
+              <div className="form-check">
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  name="exampleRadios"
+                  id="exampleRadios2"
+                  checked={store.periodo_alquiler == "por días" ? true : false}
+                  onChange={actions.bulletDay}
+                />
+                <label className="form-check-label" for="exampleRadios2">
+                  Días
+                </label>
+              </div>
+            </div>
+          ) : (
+            ""
+          )}
           {/* rango de precio */}
           <div className="selector mx-3 mb-3">
             <div className="pb-2">
               <span className="">Rango de Precio</span>
             </div>
-            {store.operacion == "todas" || store.operacion == "alquiler" ? (
+            {(store.operacion == "todas" || store.operacion == "alquiler") &&
+            store.periodo_alquiler == "por meses" ? (
               <div className="d-flex">
                 <select
                   onChange={actions.updatePreciomin}
@@ -90,11 +127,17 @@ export const Aside = () => {
                   value={store.preciomin == 0 ? "Mín" : store.preciomin}
                 >
                   <option className="">Mín</option>
+                  <option className="">500</option>
+                  <option className="">750</option>
                   <option className="">1000</option>
+                  <option className="">1250</option>
+                  <option className="">1500</option>
+                  <option className="">1750</option>
                   <option className="">2000</option>
+                  <option className="">2500</option>
                   <option className="">3000</option>
+                  <option className="">3500</option>
                   <option className="">4000</option>
-                  <option className="">5000</option>
                 </select>
                 <select
                   onChange={actions.updatePreciomax}
@@ -103,11 +146,59 @@ export const Aside = () => {
                   value={store.preciomax == 999999999 ? "Máx" : store.preciomax}
                 >
                   <option className="">Máx</option>
+                  <option className="">500</option>
+                  <option className="">750</option>
+                  <option className="">1000</option>
+                  <option className="">1250</option>
+                  <option className="">1500</option>
+                  <option className="">1750</option>
+                  <option className="">2000</option>
+                  <option className="">2500</option>
+                  <option className="">3000</option>
+                  <option className="">3500</option>
+                  <option className="">4000</option>
+                </select>
+              </div>
+            ) : (store.operacion == "todas" || store.operacion == "alquiler") &&
+              store.periodo_alquiler == "por días" ? (
+              <div className="d-flex">
+                <select
+                  onChange={actions.updatePreciomin}
+                  className="form-select me-1"
+                  aria-label="Default select example"
+                  value={store.preciomin == 0 ? "Mín" : store.preciomin}
+                >
+                  <option className="">Mín</option>
+                  <option className="">50</option>
+                  <option className="">75</option>
+                  <option className="">100</option>
+                  <option className="">150</option>
+                  <option className="">200</option>
+                  <option className="">300</option>
+                  <option className="">400</option>
+                  <option className="">500</option>
+                  <option className="">750</option>
                   <option className="">1000</option>
                   <option className="">2000</option>
-                  <option className="">3000</option>
-                  <option className="">4000</option>
-                  <option className="">5000</option>
+                </select>
+                <select
+                  onChange={actions.updatePreciomax}
+                  className="form-select ms-1"
+                  aria-label="Default select example"
+                  value={store.preciomax == 999999999 ? "Máx" : store.preciomax}
+                >
+                  <option className="">Máx</option>
+                  <option className="">50</option>
+                  <option className="">75</option>
+                  <option className="">100</option>
+                  <option className="">150</option>
+                  <option className="">200</option>
+                  <option className="">300</option>
+                  <option className="">400</option>
+                  <option className="">500</option>
+                  <option className="">750</option>
+                  <option className="">1000</option>
+                  <option className="">2000</option>
                 </select>
               </div>
             ) : (
@@ -120,7 +211,13 @@ export const Aside = () => {
                 >
                   <option className="">Mín</option>
                   <option className="">100000</option>
+                  <option className="">150000</option>
                   <option className="">200000</option>
+                  <option className="">250000</option>
+                  <option className="">300000</option>
+                  <option className="">350000</option>
+                  <option className="">400000</option>
+                  <option className="">450000</option>
                   <option className="">500000</option>
                   <option className="">750000</option>
                   <option className="">1000000</option>
@@ -133,7 +230,13 @@ export const Aside = () => {
                 >
                   <option className="">Máx</option>
                   <option className="">100000</option>
+                  <option className="">150000</option>
                   <option className="">200000</option>
+                  <option className="">250000</option>
+                  <option className="">300000</option>
+                  <option className="">350000</option>
+                  <option className="">400000</option>
+                  <option className="">450000</option>
                   <option className="">500000</option>
                   <option className="">750000</option>
                   <option className="">1000000</option>

--- a/src/front/js/component/feed.js
+++ b/src/front/js/component/feed.js
@@ -48,11 +48,15 @@ export const Feed = () => {
                     </div>
                   </div>
                   <h3 className="card-title">
-                    {`${item.precio} ${
-                      item.tipo_operacion == "alquiler"
-                        ? " Euros/mes"
-                        : " Euros"
-                    }`}
+                    {item.tipo_operacion == "alquiler" &&
+                    store.periodo_alquiler == "por meses"
+                      ? `${item.precio} Euros/mes`
+                      : item.tipo_operacion == "alquiler" &&
+                        store.periodo_alquiler == "por días"
+                      ? `${Math.floor(item.precio / 25 + 1)} Euros/día`
+                      : item.tipo_operacion == "compra"
+                      ? `${item.precio} Euros`
+                      : "Información no encontrada"}
                   </h3>
                   <div className="características d-lg-flex wrap justify-content-start pt-2">
                     <div className="pe-2">{`Habitaciones: ${item.habitaciones}`}</div>

--- a/src/front/js/component/tablero.js
+++ b/src/front/js/component/tablero.js
@@ -67,6 +67,7 @@ export const Tablero = () => {
               Listado
             </button>
             <button
+              disabled
               className="nav-link"
               type="button"
               onClick={actions.updateVistaMapa}
@@ -84,6 +85,7 @@ export const Tablero = () => {
               Listado
             </button>
             <button
+              disabled
               className="nav-link active"
               type="button"
               onClick={actions.updateVistaMapa}

--- a/src/front/js/pages/home.js
+++ b/src/front/js/pages/home.js
@@ -109,11 +109,17 @@ export const Home = () => {
                     value={store.preciomin == 0 ? "Mín" : store.preciomin}
                   >
                     <option className="">Mín</option>
+                    <option className="">500</option>
+                    <option className="">750</option>
                     <option className="">1000</option>
+                    <option className="">1250</option>
+                    <option className="">1500</option>
+                    <option className="">1750</option>
                     <option className="">2000</option>
+                    <option className="">2500</option>
                     <option className="">3000</option>
+                    <option className="">3500</option>
                     <option className="">4000</option>
-                    <option className="">5000</option>
                   </select>
                   <select
                     onChange={actions.updatePreciomax}
@@ -124,11 +130,17 @@ export const Home = () => {
                     }
                   >
                     <option className="">Máx</option>
+                    <option className="">500</option>
+                    <option className="">750</option>
                     <option className="">1000</option>
+                    <option className="">1250</option>
+                    <option className="">1500</option>
+                    <option className="">1750</option>
                     <option className="">2000</option>
+                    <option className="">2500</option>
                     <option className="">3000</option>
+                    <option className="">3500</option>
                     <option className="">4000</option>
-                    <option className="">5000</option>
                   </select>
                 </div>
               ) : (
@@ -141,7 +153,13 @@ export const Home = () => {
                   >
                     <option className="">Mín</option>
                     <option className="">100000</option>
+                    <option className="">150000</option>
                     <option className="">200000</option>
+                    <option className="">250000</option>
+                    <option className="">300000</option>
+                    <option className="">350000</option>
+                    <option className="">400000</option>
+                    <option className="">450000</option>
                     <option className="">500000</option>
                     <option className="">750000</option>
                     <option className="">1000000</option>
@@ -156,7 +174,13 @@ export const Home = () => {
                   >
                     <option className="">Máx</option>
                     <option className="">100000</option>
+                    <option className="">150000</option>
                     <option className="">200000</option>
+                    <option className="">250000</option>
+                    <option className="">300000</option>
+                    <option className="">350000</option>
+                    <option className="">400000</option>
+                    <option className="">450000</option>
                     <option className="">500000</option>
                     <option className="">750000</option>
                     <option className="">1000000</option>

--- a/src/front/js/pages/single.js
+++ b/src/front/js/pages/single.js
@@ -6,6 +6,9 @@ import "../../styles/single.css";
 export const Single = () => {
   const { store, actions } = useContext(Context);
   const [nroFoto, setNroFoto] = useState(0);
+  const [periodo, setPeriodo] = useState(
+    localStorage.getItem("periodo_alquiler")
+  );
   const [elemento, setElemento] = useState(
     JSON.parse(localStorage.getItem("resp_element"))
   );
@@ -107,9 +110,19 @@ export const Single = () => {
               }`}</h5>
               <h5 className="">{`Provincia: ${elemento.provincia}`}</h5>
               <h5 className="">{`Comunidad Autónoma: ${elemento.comunidad}`}</h5>
-              <h5 className="">{`Precio: ${elemento.precio} ${
-                elemento.tipo_operacion != "compra" ? " Euros/mes" : "Euros"
-              }`}</h5>
+              <h5 className="text-decoration-underline">
+                <b>
+                  {elemento.tipo_operacion == "alquiler" &&
+                  periodo == "por meses"
+                    ? `${elemento.precio} Euros/mes`
+                    : elemento.tipo_operacion == "alquiler" &&
+                      periodo == "por días"
+                    ? `${Math.floor(elemento.precio / 25 + 1)} Euros/día`
+                    : elemento.tipo_operacion == "compra"
+                    ? `${elemento.precio} Euros`
+                    : "Información no encontrada"}
+                </b>
+              </h5>
               <div className="características wrap pt-2">
                 <h5 className="">Características:</h5>
                 <h5 className="px-4">{`- Habitaciones: ${elemento.habitaciones}`}</h5>

--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -88,6 +88,7 @@ const getState = ({ getStore, getActions, setStore }) => {
       caracteristica_terraza: false,
       habitaciones: "cualquiera",
       baños: "cualquiera",
+      periodo_alquiler: "por meses",
       /*------------------------------------------ FIN DE LAS VARIABLES DE FILTROS -----------------------------------------------------*/
     },
     actions: {
@@ -512,6 +513,7 @@ const getState = ({ getStore, getActions, setStore }) => {
         );
         localStorage.setItem("habitaciones", store.habitaciones);
         localStorage.setItem("baños", store.baños);
+        localStorage.setItem("periodo_alquiler", store.periodo_alquiler);
       },
       syncLocalStorageToStore: () => {
         // funcion recupera datos de LocalStorage y los guarda en el store nuevamente al cargar la página
@@ -542,6 +544,9 @@ const getState = ({ getStore, getActions, setStore }) => {
         });
         setStore({ habitaciones: localStorage.getItem("habitaciones") });
         setStore({ baños: localStorage.getItem("baños") });
+        setStore({
+          periodo_alquiler: localStorage.getItem("periodo_alquiler"),
+        });
       },
       backHome: () => {
         // esta funcion resetea los filtros al volver al home desde el nav o al refrescar el home
@@ -563,6 +568,7 @@ const getState = ({ getStore, getActions, setStore }) => {
         setStore({ habitaciones: "cualquiera" });
         setStore({ baños: "cualquiera" });
         setStore({ body_response: "buscando coincidencias..." });
+        setStore({ periodo_alquiler: "por meses" });
       },
 
       /*------------------------------------- FIN DE LAS FUNCIONES DE ENTREGA Y RECUPERACION DE DATA ------------------------------ */
@@ -611,6 +617,14 @@ const getState = ({ getStore, getActions, setStore }) => {
         } catch (error) {
           console.log("The fetch has failed: ", error);
         }
+      },
+      bulletMonth: (e) => {
+        setStore({ periodo_alquiler: "por meses" });
+        getActions().fillLocalStorage();
+      },
+      bulletDay: (e) => {
+        setStore({ periodo_alquiler: "por días" });
+        getActions().fillLocalStorage();
       },
     },
   };


### PR DESCRIPTION
Se hizo la ampliación del listado de rango de precios, para que sea más amigable se creó rangos más cortos. Tambié se implementó la periodicidad por dias de alquiler, la cual recalcula sólo a nivel de front el precio entre 25 (no 30) con redondeo entero superior.